### PR TITLE
Fixed not being able to use navigation with sideDrawer

### DIFF
--- a/DBMS/Backend/util/location.js
+++ b/DBMS/Backend/util/location.js
@@ -5,4 +5,4 @@ async function getcoordinates(adress) {
         lng:45.4344
     };
 }
-module.exports = getcoordinates;s
+module.exports = getcoordinates;

--- a/DBMS/Frontend/src/shared/Components/UIElements/Backdrop.css
+++ b/DBMS/Frontend/src/shared/Components/UIElements/Backdrop.css
@@ -5,5 +5,5 @@
   width: 100%;
   height: 100vh;
   background: rgba(0, 0, 0, 0.75);
-  z-index: 10;
+  z-index: 4;
 }


### PR DESCRIPTION
The zindex for the backdrop was higher than the zindex for the sideDrawer and navigation bar which placed the backdrop over top of the navigation elements. Lowering this zindex below the zindex of the navigation elements allows for the sideDrawer navigation elements to be used.